### PR TITLE
Set UTM cookie when displaying blogposts

### DIFF
--- a/_includes/utm_cookies.html
+++ b/_includes/utm_cookies.html
@@ -1,0 +1,17 @@
+<script>
+$(document).ready(function() {
+  if (document.cookie.includes("u_source")) {
+    return;
+  };
+
+  var date = new Date();
+  date.setMonth(date.getMonth() + 6);
+  var dateString = date.toUTCString();
+  var cookieAttributesString = "path=/;domain=knapsackpro.com;expires=" + dateString + ";";
+  var utmCampaignString = document.location.pathname.substring(6);
+
+  document.cookie = "u_source=docs_knapsackpro;" + cookieAttributesString;
+  document.cookie = "u_medium=blog_post;" + cookieAttributesString;
+  document.cookie = "u_campaign=" + utmCampaignString + ";" + cookieAttributesString;
+});
+</script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,8 @@
 ---
 layout: default
 ---
+{% include utm_cookies.html %}
+
 <article class="post" itemscope itemtype="http://schema.org/BlogPosting">
 
   <header class="post-header">


### PR DESCRIPTION
Sets UTM tag cookies when displaying blogposts.

The cookies are set with main domain specified, which will make them accessible by the app serving `knapsackpro.com` website.