### PR TITLE
Update travis parallel build key from matrix to jobs

### DIFF
--- a/docs/ruby/knapsack/readme.md
+++ b/docs/ruby/knapsack/readme.md
@@ -623,7 +623,7 @@ env:
     - RAILS_ENV=test
     - MY_GLOBAL_VAR=123
     - CI_NODE_TOTAL=2
-  matrix:
+  jobs:
     - CI_NODE_INDEX=0
     - CI_NODE_INDEX=1
 {% endhighlight %}


### PR DESCRIPTION
As far as I read https://docs.travis-ci.com/user/speeding-up-the-build
`matrix` keyword has been changed to `jobs` in latest Travis.