### PR TITLE
Cookie banner small improvements - add GA event etc

### DIFF
--- a/_includes/cookie_consent.html
+++ b/_includes/cookie_consent.html
@@ -25,14 +25,18 @@
       document.getElementById('js-cookies-message').style.display = 'block';
     };
 
-    document.getElementById('js-cookies-close').addEventListener("click",function() {
+    $("#js-cookies-close").click(function(e) {
+      e.preventDefault()
+
+      $("#js-cookies-message").fadeOut()
+
       var date = new Date();
       date.setMonth(date.getMonth() + 12);
       var dateString = date.toUTCString();
 
       document.cookie = cookieName + "=true;expires=" + dateString
-      document.getElementById('js-cookies-message').style.display = 'none';
-      location.reload();
+
+      window.ga('send', 'event', 'Cookie consent', 'Cookie consent - I agree', 'Alert');
     });
   });
 </script>


### PR DESCRIPTION
* Prevent page jumping up after click on button by adding e.preventDefault. And also stop reloading page with location.reload (maybe we will need later if we will want to reload js code that was not loaded on first page visit because there was not yet consent from user)
* Use jquery to fadeOut cookie banner (keep it consistent with homepage). 
* Send event to Google Analytics when someone agrees