### PR TITLE
Migrate to Google Analytics 4

### DIFF
--- a/_includes/cookie_consent.html
+++ b/_includes/cookie_consent.html
@@ -36,7 +36,7 @@
 
       document.cookie = cookieName + "=true;expires=" + dateString
 
-      window.ga('send', 'event', 'Cookie consent', 'Cookie consent - I agree', 'Alert');
+      gtag('event', 'Cookie consent - I agree', {});
     });
   });
 </script>

--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -1,9 +1,9 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JPGP34N3JJ"></script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-  ga('create', 'UA-54121327-2', 'auto');
-  ga('send', 'pageview');
+  gtag('config', 'G-JPGP34N3JJ');
 </script>


### PR DESCRIPTION
Migrate to Google Analytics 4

# context

Universal Analytics will be going away

> [Google Analytics 4](https://support.google.com/analytics/answer/10089681) is our next-generation measurement solution, and it's replacing Universal Analytics. On July 1, 2023, standard Universal Analytics properties will stop processing new hits. If you still rely on Universal Analytics, we recommend that you [prepare to use Google Analytics 4](https://support.google.com/analytics/answer/10759417) going forward.

https://support.google.com/analytics/answer/11583528