### PR TITLE
Detect Docusaurus files changes and trigger Jekyll build along with the Docusaurus build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ _site
 .jekyll-cache
 .jekyll-metadata
 
+# custom jekyll files
+.jekyll_build_trigger
+
 # nodejs
 /node_modules
 

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,14 @@
 guard 'rake', task: 'api:generate_docs' do
   watch(%r{^_api/.+\.raml$})
 end
+
+guard 'rake', task: 'jekyll_build_trigger' do
+  ignore /docusaurus\/\.docusaurus/
+  ignore /docusaurus\/build/
+  ignore /docusaurus\/node_modules/
+
+  watch(%r{^docusaurus/docs/.+$})
+  watch(%r{^docusaurus/src/.+$})
+  watch(%r{^docusaurus/static/.+$})
+  watch(%r{^docusaurus/.+\.js$})
+end

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Compiled files are in `api` directory. Please commit them into repository.
 
 ## Guard
 
-You can run guard to recompile raml files whenever they change.
+You can run Guard to recompile RAML files whenever they change.
 
     $ guard
+
+Guard is also monitoring the Docusaurus files. If anything changes, then Jekyll build is triggered along with the Docusaurus build.
+Ensure you have a separate terminal window running the following command to run Jekyll build:
+
+    $ bundle exec jekyll serve --watch --future
+

--- a/_lib/tasks/jekyll_build_trigger.rake
+++ b/_lib/tasks/jekyll_build_trigger.rake
@@ -1,0 +1,6 @@
+task :jekyll_build_trigger do
+  jekyll_build_trigger_file = "#{ROOT_PATH}/.jekyll_build_trigger"
+  cmd = "touch #{jekyll_build_trigger_file}"
+  puts `#{cmd}`
+  puts "Touched the #{jekyll_build_trigger_file} file to trigger a jekyll build."
+end


### PR DESCRIPTION
Detect Docusaurus files changes and trigger Jekyll build along with the Docusaurus build.

Thanks to that you can run in your terminal:

```
$ guard
```

and in a separate window:

```
$ bundle exec jekyll serve --watch --future
```

When Guard detects changes in Docusaurus files then it touches the `.jekyll_build_trigger` file on the disk. This is detected by the command  `bundle exec jekyll serve --watch --future` and triggers Jekyll build. After Jekyll build the Docusaurus plugin (`_plugins/docusaurus.rb`) is triggered so Docusaurus is also build.