### PR TITLE
Update to `actions/checkout@v3` that uses node16

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📂 checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: 💎 setup ruby
         uses: ruby/setup-ruby@v1
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: 📂 checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: 🔍 update index on Algolia
         uses: darrenjennings/algolia-docsearch-action@v0.2.0


### PR DESCRIPTION
I noticed this warning on Github Actions:
<img width="1975" alt="image" src="https://user-images.githubusercontent.com/662545/220700489-6f88a43b-239c-4778-8b80-1daa1a5fa060.png">

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

CI build with the warning: https://github.com/KnapsackPro/docs.knapsackpro.com/actions/runs/4244460395

`actions/checkout@v3` docs: 
https://github.com/actions/checkout

I've updated the `actions/checkout@v2` to `actions/checkout@v3` but in order to test this we need to merge this to the `main` branch.