### PR TITLE
Add JUnit XML and JSON examples for RSpec formatters in a separate tabs

### DIFF
--- a/docusaurus/docs/ruby/formatters/_json_queue_mode.md
+++ b/docusaurus/docs/ruby/formatters/_json_queue_mode.md
@@ -1,0 +1,32 @@
+```bash
+# Refer to your CI docs for `$MY_CI_NODE_INDEX`
+export KNAPSACK_PRO_CI_NODE_INDEX=$MY_CI_NODE_INDEX
+
+bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format json --out tmp/rspec_$KNAPSACK_PRO_CI_NODE_INDEX.json]"
+```
+
+```ruby
+# spec_helper.rb or rails_helper.rb
+
+# `TMP_REPORT` must be the same path as `--out`
+# `TMP_REPORT` must be a full path (no `~`)
+TMP_REPORT = "tmp/tmp_rspec_#{ENV['KNAPSACK_PRO_CI_NODE_INDEX']}.json"
+FINAL_REPORT = "tmp/final_rspec_#{ENV['KNAPSACK_PRO_CI_NODE_INDEX']}.json"
+
+KnapsackPro::Hooks::Queue.after_subset_queue do |queue_id, subset_queue_id|
+  if File.exist?(TMP_REPORT)
+    FileUtils.mv(TMP_REPORT, FINAL_REPORT)
+  end
+end
+```
+
+`FINAL_REPORT` will contain all the tests run on the CI node (not just the last subset). For more information, you can read this [Github issue](https://github.com/KnapsackPro/knapsack_pro-ruby/issues/40).
+
+If your CI nodes write to the same disk, you need to append the CI node index to the solution presented above to avoid conflicts:
+
+```ruby
+TMP_REPORT = "tmp/tmp_rspec_#{ENV['KNAPSACK_PRO_CI_NODE_INDEX']}.json"
+FINAL_REPORT = "tmp/final_rspec_#{ENV['KNAPSACK_PRO_CI_NODE_INDEX']}.json"
+```
+
+This applies also if you are running parallel test processes on each CI node (see our page on to integrate Knapsack Pro with [`parallel_tests`](parallel_tests.md) for an example).

--- a/docusaurus/docs/ruby/formatters/_json_regular_mode.md
+++ b/docusaurus/docs/ruby/formatters/_json_regular_mode.md
@@ -1,0 +1,5 @@
+Format stdout with the `documentation` formatter and file output with the `json` formatter:
+
+```bash
+bundle exec rake "knapsack_pro:rspec[--format documentation --format json --out tmp/rspec.json]"
+```

--- a/docusaurus/docs/ruby/formatters/_json_regular_mode.md
+++ b/docusaurus/docs/ruby/formatters/_json_regular_mode.md
@@ -1,5 +1,3 @@
-Format stdout with the `documentation` formatter and file output with the `json` formatter:
-
 ```bash
 bundle exec rake "knapsack_pro:rspec[--format documentation --format json --out tmp/rspec.json]"
 ```

--- a/docusaurus/docs/ruby/formatters/_xml_queue_mode.md
+++ b/docusaurus/docs/ruby/formatters/_xml_queue_mode.md
@@ -1,0 +1,34 @@
+You need to install the [`rspec_junit_formatter`](https://github.com/sj26/rspec_junit_formatter) gem.
+
+```bash
+# Refer to your CI docs for `$MY_CI_NODE_INDEX`
+export KNAPSACK_PRO_CI_NODE_INDEX=$MY_CI_NODE_INDEX
+
+bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format RspecJunitFormatter --out tmp/rspec_$KNAPSACK_PRO_CI_NODE_INDEX.xml]"
+```
+
+```ruby
+# spec_helper.rb or rails_helper.rb
+
+# `TMP_REPORT` must be the same path as `--out`
+# `TMP_REPORT` must be a full path (no `~`)
+TMP_REPORT = "tmp/tmp_rspec_#{ENV['KNAPSACK_PRO_CI_NODE_INDEX']}.xml"
+FINAL_REPORT = "tmp/final_rspec_#{ENV['KNAPSACK_PRO_CI_NODE_INDEX']}.xml"
+
+KnapsackPro::Hooks::Queue.after_subset_queue do |queue_id, subset_queue_id|
+  if File.exist?(TMP_REPORT)
+    FileUtils.mv(TMP_REPORT, FINAL_REPORT)
+  end
+end
+```
+
+`FINAL_REPORT` will contain all the tests run on the CI node (not just the last subset). For more information, you can read this [Github issue](https://github.com/KnapsackPro/knapsack_pro-ruby/issues/40).
+
+If your CI nodes write to the same disk, you need to append the CI node index to the solution presented above to avoid conflicts:
+
+```ruby
+TMP_REPORT = "tmp/tmp_rspec_#{ENV['KNAPSACK_PRO_CI_NODE_INDEX']}.xml"
+FINAL_REPORT = "tmp/final_rspec_#{ENV['KNAPSACK_PRO_CI_NODE_INDEX']}.xml"
+```
+
+This applies also if you are running parallel test processes on each CI node (see our page on to integrate Knapsack Pro with [`parallel_tests`](parallel_tests.md) for an example).

--- a/docusaurus/docs/ruby/formatters/_xml_regular_mode.md
+++ b/docusaurus/docs/ruby/formatters/_xml_regular_mode.md
@@ -1,0 +1,7 @@
+You need to install the [`rspec_junit_formatter`](https://github.com/sj26/rspec_junit_formatter) gem.
+
+Format stdout with the `documentation` formatter and file output with the `RspecJunitFormatter` formatter:
+
+```bash
+bundle exec rake "knapsack_pro:rspec[--format documentation --format RspecJunitFormatter --out tmp/rspec.xml]"
+```

--- a/docusaurus/docs/ruby/formatters/_xml_regular_mode.md
+++ b/docusaurus/docs/ruby/formatters/_xml_regular_mode.md
@@ -1,7 +1,5 @@
 You need to install the [`rspec_junit_formatter`](https://github.com/sj26/rspec_junit_formatter) gem.
 
-Format stdout with the `documentation` formatter and file output with the `RspecJunitFormatter` formatter:
-
 ```bash
 bundle exec rake "knapsack_pro:rspec[--format documentation --format RspecJunitFormatter --out tmp/rspec.xml]"
 ```

--- a/docusaurus/docs/ruby/rspec.md
+++ b/docusaurus/docs/ruby/rspec.md
@@ -3,6 +3,13 @@ pagination_next: null
 pagination_prev: null
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import XmlRegularModeFormatter from './formatters/_xml_regular_mode.md';
+import JsonRegularModeFormatter from './formatters/_json_regular_mode.md';
+import XmlQueueModeFormatter from './formatters/_xml_queue_mode.md';
+import JsonQueueModeFormatter from './formatters/_json_queue_mode.md';
+
 # Using Knapsack Pro with RSpec
 
 import { TOCBottom } from '@site/src/components/TOCBottom'
@@ -55,48 +62,29 @@ See [Split by test examples](split-by-test-examples.md).
 
 ## Formatters ([`rspec_junit_formatter`](https://github.com/sj26/rspec_junit_formatter), [`json`](https://rspec.info/features/3-12/rspec-core/formatters/json-formatter/))
 
+Format stdout with the `documentation` formatter and file output with any RSpec supported formatter.
+
 ### Regular Mode
 
-Format stdout with the `documentation` formatter and file output with the `RspecJunitFormatter` formatter (you can use any RSpec supported formatter):
-
-```bash
-bundle exec rake "knapsack_pro:rspec[--format documentation --format RspecJunitFormatter --out tmp/rspec.xml]"
-```
+<Tabs>
+  <TabItem value="junit-formatter" label="JUnit XML" default>
+    <XmlRegularModeFormatter />
+  </TabItem>
+  <TabItem value="json-formatter" label="JSON">
+    <JsonRegularModeFormatter />
+  </TabItem>
+</Tabs>
 
 ### Queue Mode
 
-```bash
-# Refer to your CI docs for `$MY_CI_NODE_INDEX`
-export KNAPSACK_PRO_CI_NODE_INDEX=$MY_CI_NODE_INDEX
-
-bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format RspecJunitFormatter --out tmp/rspec_$KNAPSACK_PRO_CI_NODE_INDEX.xml]"
-```
-
-```ruby
-# spec_helper.rb or rails_helper.rb
-
-# `TMP_REPORT` must be the same path as `--out`
-# `TMP_REPORT` must be a full path (no `~`)
-TMP_REPORT = "tmp/tmp_rspec_#{ENV['KNAPSACK_PRO_CI_NODE_INDEX']}.xml"
-FINAL_REPORT = "tmp/final_rspec_#{ENV['KNAPSACK_PRO_CI_NODE_INDEX']}.xml"
-
-KnapsackPro::Hooks::Queue.after_subset_queue do |queue_id, subset_queue_id|
-  if File.exist?(TMP_REPORT)
-    FileUtils.mv(TMP_REPORT, FINAL_REPORT)
-  end
-end
-```
-
-`FINAL_REPORT` will contain all the tests run on the CI node (not just the last subset). For more information, you can read this [Github issue](https://github.com/KnapsackPro/knapsack_pro-ruby/issues/40).
-
-If your CI nodes write to the same disk, you need to append the CI node index to the solution presented above to avoid conflicts:
-
-```ruby
-TMP_REPORT = "tmp/tmp_rspec_#{ENV['KNAPSACK_PRO_CI_NODE_INDEX']}.xml"
-FINAL_REPORT = "tmp/final_rspec_#{ENV['KNAPSACK_PRO_CI_NODE_INDEX']}.xml"
-```
-
-This applies also if you are running parallel test processes on each CI node (see our page on to integrate Knapsack Pro with [`parallel_tests`](parallel_tests.md) for an example).
+<Tabs>
+  <TabItem value="junit-formatter" label="JUnit XML" default>
+    <XmlQueueModeFormatter />
+  </TabItem>
+  <TabItem value="json-formatter" label="JSON">
+    <JsonQueueModeFormatter />
+  </TabItem>
+</Tabs>
 
 ## Troubleshooting
 

--- a/docusaurus/docs/ruby/rspec.md
+++ b/docusaurus/docs/ruby/rspec.md
@@ -3,6 +3,8 @@ pagination_next: null
 pagination_prev: null
 ---
 
+import { TOCBottom } from '@site/src/components/TOCBottom'
+import { IconExternalLink } from '@site/src/components/IconExternalLink'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import XmlRegularModeFormatter from './formatters/_xml_regular_mode.md';
@@ -11,9 +13,6 @@ import XmlQueueModeFormatter from './formatters/_xml_queue_mode.md';
 import JsonQueueModeFormatter from './formatters/_json_queue_mode.md';
 
 # Using Knapsack Pro with RSpec
-
-import { TOCBottom } from '@site/src/components/TOCBottom'
-import { IconExternalLink } from '@site/src/components/IconExternalLink'
 
 <TOCBottom heading="Reference" Icon={<IconExternalLink />}>
 

--- a/docusaurus/docs/ruby/rspec.md
+++ b/docusaurus/docs/ruby/rspec.md
@@ -53,7 +53,7 @@ If you are seeking faster performance on your CI, you may want to read [Parallel
 
 See [Split by test examples](split-by-test-examples.md).
 
-## Formatters ([`rspec_junit_formatter`](https://github.com/sj26/rspec_junit_formatter), [`json`](https://relishapp.com/rspec/rspec-core/v/3-12/docs/formatters/json-formatter))
+## Formatters ([`rspec_junit_formatter`](https://github.com/sj26/rspec_junit_formatter), [`json`](https://rspec.info/features/3-12/rspec-core/formatters/json-formatter/))
 
 ### Regular Mode
 


### PR DESCRIPTION
Add JUnit XML and JSON examples for RSpec formatters in a separate tabs.

Inspired by:

* https://knapsackpro.com/faq/question/how-to-use-json-formatter-for-rspec
* https://knapsackpro.com/faq/question/how-to-use-junit-formatter

# Docusaurus references

Tabs feature in Docusaurus
https://docusaurus.io/docs/markdown-features/tabs

How to import partials in docusaurus:
https://docusaurus.io/docs/next/markdown-features/react#importing-markdown
to make it work with tabs
https://docusaurus.canny.io/feature-requests/p/ability-to-use-markdown-in-tabs