### PR TITLE
docs: use npx instead of npm bin

### DIFF
--- a/docusaurus/docs/cypress/cookbook.md
+++ b/docusaurus/docs/cypress/cookbook.md
@@ -12,7 +12,7 @@ Since Knapsack Pro runs Cypress multiple times, you need to set [`trashAssetsBef
 You can do so by either invoking Knapsack Pro with:
 
 ```bash
-$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 Or in `cypress.config.js`:
@@ -28,7 +28,7 @@ Or in `cypress.config.js`:
 You can pass the `testingType` option to run [component tests](https://docs.cypress.io/guides/component-testing/introduction):
 
 ```bash
-$(npm bin)/knapsack-pro-cypress --testingType=component
+npx knapsack-pro-cypress --testingType=component
 ```
 
 ## Record CI builds in Cypress Dashboard
@@ -36,33 +36,33 @@ $(npm bin)/knapsack-pro-cypress --testingType=component
 ```bash
 export CYPRESS_RECORD_KEY=MY_RECORD_KEY
 
-$(npm bin)/knapsack-pro-cypress --record
+npx knapsack-pro-cypress --record
 ```
 
 If Cypress supports your CI, it will merge the tests executed on parallel nodes into a single run in the Cypress Dashboard using the CI build ID. Otherwise, you will need to specify it:
 
 ```bash
-$(npm bin)/knapsack-pro-cypress --record --ci-build-id $MY_CI_BUILD_ID
+npx knapsack-pro-cypress --record --ci-build-id $MY_CI_BUILD_ID
 ```
 
 You should replace `$MY_CI_BUILD_ID` with the correct environment variable provided by your CI:
 
-| CI Provider    | Environment Variable |
-| -------------- | -------------------- |
-| AppVeyor       | `APPVEYOR_BUILD_NUMBER` |
-| Bamboo         | `BAMBOO_BUILD_NUMBER` |
+| CI Provider    | Environment Variable     |
+| -------------- | ------------------------ |
+| AppVeyor       | `APPVEYOR_BUILD_NUMBER`  |
+| Bamboo         | `BAMBOO_BUILD_NUMBER`    |
 | Buildkite      | `BUILDKITE_BUILD_NUMBER` |
-| Circle         | `CIRCLE_WORKFLOW_ID` |
-| Cirrus         | `CIRRUS_BUILD_ID` |
-| Codeship       | `CI_BUILD_NUMBER` |
-| Codeship Basic | `CI_BUILD_NUMBER` |
-| Codeship Pro   | `CI_BUILD_ID` |
-| Drone          | `DRONE_BUILD_NUMBER` |
-| Gitlab         | `CI_PIPELINE_ID` |
-| Github Actions | `GITHUB_RUN_ID` |
-| Heroku         | `HEROKU_TEST_RUN_ID` |
-| Jenkins        | `BUILD_NUMBER` |
+| Circle         | `CIRCLE_WORKFLOW_ID`     |
+| Cirrus         | `CIRRUS_BUILD_ID`        |
+| Codeship       | `CI_BUILD_NUMBER`        |
+| Codeship Basic | `CI_BUILD_NUMBER`        |
+| Codeship Pro   | `CI_BUILD_ID`            |
+| Drone          | `DRONE_BUILD_NUMBER`     |
+| Gitlab         | `CI_PIPELINE_ID`         |
+| Github Actions | `GITHUB_RUN_ID`          |
+| Heroku         | `HEROKU_TEST_RUN_ID`     |
+| Jenkins        | `BUILD_NUMBER`           |
 | Semaphore 1.0  | `SEMAPHORE_BUILD_NUMBER` |
-| Semaphore 2.0  | `SEMAPHORE_WORKFLOW_ID` |
-| Travis         | `TRAVIS_BUILD_ID` |
-| Codefresh.io   | `CF_BUILD_ID` |
+| Semaphore 2.0  | `SEMAPHORE_WORKFLOW_ID`  |
+| Travis         | `TRAVIS_BUILD_ID`        |
+| Codefresh.io   | `CF_BUILD_ID`            |

--- a/docusaurus/docs/cypress/guide/index.md
+++ b/docusaurus/docs/cypress/guide/index.md
@@ -88,7 +88,7 @@ Remember to configure the number of parallel CI nodes in AppVeyor.
 KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=0 \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN \
-$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 </TabItem>
@@ -98,7 +98,7 @@ $(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=1 \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN \
-$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 </TabItem>
@@ -108,7 +108,7 @@ $(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=N-1 \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN \
-$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 </TabItem>
@@ -134,21 +134,21 @@ Remember to configure the `parallelism` parameter in your build step.
 <TabItem value="node-1" label="Node 1">
 
 ```bash
-$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 </TabItem>
 <TabItem value="node-2" label="Node 2">
 
 ```bash
-$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 </TabItem>
 <TabItem value="node-n" label="Node N">
 
 ```bash
-$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 </TabItem>
@@ -164,7 +164,7 @@ steps:
       - docker-compose#3.0.3:
         run: app
         # highlight-next-line
-        command: $(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+        command: npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
         config: docker-compose.test.yml
         # highlight-start
         env:
@@ -210,7 +210,7 @@ jobs:
       # highlight-start
       - run:
         name: cypress with @knapsack-pro/cypress
-        command: $(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+        command: npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
       # highlight-end
 ```
 
@@ -235,7 +235,7 @@ task:
     name: CI Node 1
     name: CI Node 2
   test_script:
-    - $(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+    - npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 Remember to set up the `KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS` as an [encrypted variable](https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables).
@@ -265,7 +265,7 @@ KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=0 \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN \
 KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true\
-$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 </TabItem>
@@ -276,7 +276,7 @@ KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=1 \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN \
 KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true\
-$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 </TabItem>
@@ -287,7 +287,7 @@ KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=N-1 \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN \
 KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true\
-$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 </TabItem>
@@ -358,7 +358,7 @@ steps:
     commands:
       # highlight-start
       - (npm run start:ci &) && echo "npm run start:ci running in the background"
-      - $(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+      - npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
       # highlight-end
 ```
 
@@ -453,7 +453,7 @@ jobs:
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
         run: |
-          $(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+          npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
       # highlight-end
 ```
 
@@ -472,7 +472,7 @@ test:
   parallel: 2
 
   script:
-    - KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN $(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+    - KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 See also [how to configure running parallel CI nodes in GitLab](https://docs.gitlab.com/ee/ci/yaml/#parallel).
@@ -501,7 +501,7 @@ test_ci_first_node:
   script:
     # highlight-start
     - export KNAPSACK_PRO_CI_NODE_INDEX=0
-    - KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN $(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+    - KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
     # highlight-end
 
 test_ci_second_node:
@@ -509,7 +509,7 @@ test_ci_second_node:
   script:
     # highlight-start
     - export KNAPSACK_PRO_CI_NODE_INDEX=1
-    - KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN $(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+    - KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
     # highlight-end
 ```
 
@@ -542,7 +542,7 @@ Define in `app.json`:
       "addons": ["heroku-postgresql"],
       // highlight-start
       "scripts": {
-        "test": "$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false"
+        "test": "npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false"
       },
       "env": {
         "KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS": "MY_CYPRESS_API_TOKEN"
@@ -604,7 +604,7 @@ timeout(time: 60, unit: 'MINUTES') {
         """
 
         stage('Run tests') {
-          sh """${knapsack_options} $(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false"""
+          sh """${knapsack_options} npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false"""
         }
         // highlight-end
       }
@@ -661,7 +661,7 @@ blocks:
         - name: Run tests with Knapsack Pro
           parallelism: 2
           commands:
-            - $(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+            - npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
       # highlight-end
 ```
 
@@ -684,7 +684,7 @@ Define in `.travis.yml`:
 
 ```yaml
 script:
-  - "$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false"
+  - "npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false"
 
 env:
   global:
@@ -724,7 +724,7 @@ KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=0 \
 KNAPSACK_PRO_CI_NODE_BUILD_ID=MY_BUILD_ID \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN \
-$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 </TabItem>
@@ -735,7 +735,7 @@ KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=1 \
 KNAPSACK_PRO_CI_NODE_BUILD_ID=MY_BUILD_ID \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN \
-$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 </TabItem>
@@ -746,7 +746,7 @@ KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=N-1 \
 KNAPSACK_PRO_CI_NODE_BUILD_ID=MY_BUILD_ID \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS=MY_CYPRESS_API_TOKEN \
-$(npm bin)/knapsack-pro-cypress --config trashAssetsBeforeRuns=false
+npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 ```
 
 </TabItem>

--- a/docusaurus/docs/cypress/reference.md
+++ b/docusaurus/docs/cypress/reference.md
@@ -18,7 +18,7 @@ Unless specified otherwise, everything on this page is environment variables.
 You can pass all the [supported Cypress CLI options](https://docs.cypress.io/guides/guides/module-api#Options) as command-line arguments:
 
 ```bash
-$(npm bin)/knapsack-pro-cypress --browser chrome
+npx knapsack-pro-cypress --browser chrome
 ```
 
 You can also pass options to Node with environment variables (e.g., [`--max_old_space_size`](troubleshooting.md#javascript-heap-out-of-memory)).
@@ -204,11 +204,11 @@ Example:
 ```bash
 KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=MY_CYPRESS_API_TOKEN \
 KNAPSACK_PRO_TEST_FILE_PATTERN="cypress/e2e/user/**/*.{js,jsx,coffee,cjsx}" \
-  $(npm bin)/knapsack-pro-cypress
+  npx knapsack-pro-cypress
 
 KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=MY_OTHER_CYPRESS_API_TOKEN \
 KNAPSACK_PRO_TEST_FILE_PATTERN="cypress/e2e/admin/**/*.{js,jsx,coffee,cjsx}" \
-  $(npm bin)/knapsack-pro-cypress
+  npx knapsack-pro-cypress
 ```
 
 ## `KNAPSACK_PRO_USER_SEAT`

--- a/docusaurus/docs/cypress/troubleshooting.md
+++ b/docusaurus/docs/cypress/troubleshooting.md
@@ -33,9 +33,9 @@ You can increase the memory available to Node with [`--max_old_space_size`](http
 ```bash
 export NODE_OPTIONS=--max_old_space_size=4096
 
-$(npm bin)/knapsack-pro-jest
+npx knapsack-pro-jest
 
-$(npm bin)/knapsack-pro-cypress
+npx knapsack-pro-cypress
 ```
 
 ## Debug Knapsack Pro on your development environment/machine
@@ -51,7 +51,7 @@ KNAPSACK_PRO_COMMIT_HASH=MY_COMMIT \
 KNAPSACK_PRO_CI_NODE_BUILD_ID=MY_BUILD_ID \
 KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true \
 KNAPSACK_PRO_TEST_FILE_PATTERN="cypress/e2e/**/*.{js,jsx,coffee,cjsx}" \
-$(npm bin)/knapsack-pro-cypress
+npx knapsack-pro-cypress
 ```
 
 `KNAPSACK_PRO_CI_NODE_BUILD_ID` must be the same as the CI build you are trying to reproduce (if it helps, take a look at what Knapsack Pro uses as `ciNodeBuildId` for your [CI provider](https://github.com/KnapsackPro/knapsack-pro-core-js/tree/master/src/ci-providers)).

--- a/docusaurus/docs/jest/cookbook.md
+++ b/docusaurus/docs/jest/cookbook.md
@@ -25,7 +25,7 @@ Since Knapsack Pro runs Jest multiple times, you can speed up tests execution by
 Since Knapsack Pro runs Jest multiple times, you can speed up tests execution with `--runInBand`. This way tests run serially in the current process, rather than creating a worker pool of child processes that run tests:
 
 ```bash
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 ## Use a Jest config file
@@ -39,7 +39,7 @@ To filter tests use [`KNAPSACK_PRO_TEST_FILE_PATTERN`](reference.md#knapsack_pro
 You can pass it with a [command-line argument](reference.md#command-line-arguments):
 
 ```bash
-$(npm bin)/knapsack-pro-jest --config=jest.config.e2e.js
+npx knapsack-pro-jest --config=jest.config.e2e.js
 ```
 
 ## Generate code coverage reports
@@ -47,7 +47,7 @@ $(npm bin)/knapsack-pro-jest --config=jest.config.e2e.js
 ```bash
 export KNAPSACK_PRO_COVERAGE_DIRECTORY=coverage
 
-$(npm bin)/knapsack-pro-jest --coverage
+npx knapsack-pro-jest --coverage
 ```
 
 Knapsack Pro will generate one coverage report for each batch of tests executed on the CI node. To merge the reports you may consider [this script](https://github.com/facebook/jest/issues/2418#issuecomment-478932514).
@@ -59,7 +59,7 @@ You can generate [jest-junit](https://github.com/jest-community/jest-junit) repo
 ```bash
 export JEST_JUNIT_UNIQUE_OUTPUT_NAME=true
 
-$(npm bin)/knapsack-pro-jest --ci --reporters=jest-junit
+npx knapsack-pro-jest --ci --reporters=jest-junit
 ```
 
 Knapsack Pro will generate one XML reports for each batch of tests executed on the CI node. Some CI providers (e.g., GitLab CI) can merge multiple XML files from parallel CI nodes.

--- a/docusaurus/docs/jest/guide/index.md
+++ b/docusaurus/docs/jest/guide/index.md
@@ -79,7 +79,7 @@ Remember to configure the number of parallel CI nodes in AppVeyor.
 KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=0 \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN \
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 </TabItem>
@@ -89,7 +89,7 @@ $(npm bin)/knapsack-pro-jest --runInBand
 KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=1 \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN \
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 </TabItem>
@@ -99,7 +99,7 @@ $(npm bin)/knapsack-pro-jest --runInBand
 KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=N-1 \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN \
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 </TabItem>
@@ -119,21 +119,21 @@ Remember to configure the `parallelism` parameter in your build step.
 <TabItem value="node-1" label="Node 1">
 
 ```bash
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 </TabItem>
 <TabItem value="node-2" label="Node 2">
 
 ```bash
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 </TabItem>
 <TabItem value="node-n" label="Node N">
 
 ```bash
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 </TabItem>
@@ -149,7 +149,7 @@ steps:
       - docker-compose#3.0.3:
         run: app
         # highlight-next-line
-        command: $(npm bin)/knapsack-pro-jest --runInBand
+        command: npx knapsack-pro-jest --runInBand
         config: docker-compose.test.yml
         # highlight-start
         env:
@@ -195,7 +195,7 @@ jobs:
       # highlight-start
       - run:
         name: jest with @knapsack-pro/jest
-        command: $(npm bin)/knapsack-pro-jest --runInBand
+        command: npx knapsack-pro-jest --runInBand
       # highlight-end
 ```
 
@@ -220,7 +220,7 @@ task:
     name: CI Node 1
     name: CI Node 2
   test_script:
-    - $(npm bin)/knapsack-pro-jest --runInBand
+    - npx knapsack-pro-jest --runInBand
 ```
 
 Remember to set up the `KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST` as an [encrypted variable](https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables).
@@ -250,7 +250,7 @@ KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=0 \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN \
 KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true\
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 </TabItem>
@@ -261,7 +261,7 @@ KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=1 \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN \
 KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true\
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 </TabItem>
@@ -272,7 +272,7 @@ KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=N-1 \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN \
 KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true\
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 </TabItem>
@@ -342,7 +342,7 @@ steps:
     # highlight-end
     commands:
       # highlight-start
-      - $(npm bin)/knapsack-pro-jest --runInBand
+      - npx knapsack-pro-jest --runInBand
       # highlight-end
 ```
 
@@ -433,7 +433,7 @@ jobs:
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
           KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
         run: |
-          $(npm bin)/knapsack-pro-jest --runInBand
+          npx knapsack-pro-jest --runInBand
       # highlight-end
 ```
 
@@ -452,7 +452,7 @@ test:
   parallel: 2
 
   script:
-    - KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN $(npm bin)/knapsack-pro-jest --runInBand
+    - KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN npx knapsack-pro-jest --runInBand
 ```
 
 See also [how to configure running parallel CI nodes in GitLab](https://docs.gitlab.com/ee/ci/yaml/#parallel).
@@ -481,7 +481,7 @@ test_ci_first_node:
   script:
     # highlight-start
     - export KNAPSACK_PRO_CI_NODE_INDEX=0
-    - KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN $(npm bin)/knapsack-pro-jest --runInBand
+    - KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN npx knapsack-pro-jest --runInBand
     # highlight-end
 
 test_ci_second_node:
@@ -489,7 +489,7 @@ test_ci_second_node:
   script:
     # highlight-start
     - export KNAPSACK_PRO_CI_NODE_INDEX=1
-    - KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN $(npm bin)/knapsack-pro-jest --runInBand
+    - KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN npx knapsack-pro-jest --runInBand
     # highlight-end
 ```
 
@@ -522,7 +522,7 @@ Define in `app.json`:
       "addons": ["heroku-postgresql"],
       // highlight-start
       "scripts": {
-        "test": "$(npm bin)/knapsack-pro-jest --runInBand"
+        "test": "npx knapsack-pro-jest --runInBand"
       },
       "env": {
         "KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST": "MY_JEST_API_TOKEN"
@@ -584,7 +584,7 @@ timeout(time: 60, unit: 'MINUTES') {
         """
 
         stage('Run tests') {
-          sh """${knapsack_options} $(npm bin)/knapsack-pro-jest --runInBand"""
+          sh """${knapsack_options} npx knapsack-pro-jest --runInBand"""
         }
         // highlight-end
       }
@@ -641,7 +641,7 @@ blocks:
         - name: Run tests with Knapsack Pro
           parallelism: 2
           commands:
-            - $(npm bin)/knapsack-pro-jest --runInBand
+            - npx knapsack-pro-jest --runInBand
       # highlight-end
 ```
 
@@ -664,7 +664,7 @@ Define in `.travis.yml`:
 
 ```yaml
 script:
-  - "$(npm bin)/knapsack-pro-jest --runInBand"
+  - "npx knapsack-pro-jest --runInBand"
 
 env:
   global:
@@ -704,7 +704,7 @@ KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=0 \
 KNAPSACK_PRO_CI_NODE_BUILD_ID=MY_BUILD_ID \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN \
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 </TabItem>
@@ -715,7 +715,7 @@ KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=1 \
 KNAPSACK_PRO_CI_NODE_BUILD_ID=MY_BUILD_ID \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN \
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 </TabItem>
@@ -726,7 +726,7 @@ KNAPSACK_PRO_CI_NODE_TOTAL=N \
 KNAPSACK_PRO_CI_NODE_INDEX=N-1 \
 KNAPSACK_PRO_CI_NODE_BUILD_ID=MY_BUILD_ID \
 KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST=MY_JEST_API_TOKEN \
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 </TabItem>

--- a/docusaurus/docs/jest/reference.md
+++ b/docusaurus/docs/jest/reference.md
@@ -24,7 +24,7 @@ Use long options instead of short (e.g., `--updateSnapshot` instead of `-u`).
 You can pass all the [supported Jest CLI options](https://jestjs.io/docs/en/cli#options) as command-line arguments:
 
 ```bash
-$(npm bin)/knapsack-pro-jest --debug
+npx knapsack-pro-jest --debug
 ```
 
 You can also pass options to Node with environment variables (e.g., [`--max_old_space_size`](troubleshooting.md#javascript-heap-out-of-memory)).
@@ -212,11 +212,11 @@ Example:
 ```bash
 KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=MY_JEST_API_TOKEN \
 KNAPSACK_PRO_TEST_FILE_PATTERN=="src/user/__tests__/**/*.js" \
-  $(npm bin)/knapsack-pro-jest
+  npx knapsack-pro-jest
 
 KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=MY_OTHER_JEST_API_TOKEN \
 KNAPSACK_PRO_TEST_FILE_PATTERN=="src/admin/__tests__/**/*.js" \
-  $(npm bin)/knapsack-pro-jest
+  npx knapsack-pro-jest
 ```
 
 ## `KNAPSACK_PRO_USER_SEAT`

--- a/docusaurus/docs/jest/troubleshooting.md
+++ b/docusaurus/docs/jest/troubleshooting.md
@@ -10,9 +10,9 @@ pagination_prev: null
 You may have open handles preventing Jest from exiting cleanly. You can check it with [`--detectOpenHandles`](https://jestjs.io/docs/cli#--detectopenhandles) or force exit with [`--forceExit`](https://jestjs.io/docs/cli#--forceexit):
 
 ```bash
-$(npm bin)/knapsack-pro-jest --detectOpenHandles
+npx knapsack-pro-jest --detectOpenHandles
 
-$(npm bin)/knapsack-pro-jest --forceExit
+npx knapsack-pro-jest --forceExit
 ```
 
 Also, make sure `node` has enough [heap memory](#javascript-heap-out-of-memory) on your CI.
@@ -24,9 +24,9 @@ You can increase the memory available to Node with [`--max_old_space_size`](http
 ```bash
 export NODE_OPTIONS=--max_old_space_size=4096
 
-$(npm bin)/knapsack-pro-jest
+npx knapsack-pro-jest
 
-$(npm bin)/knapsack-pro-cypress
+npx knapsack-pro-cypress
 ```
 
 ## Debug Knapsack Pro on your development environment/machine
@@ -42,7 +42,7 @@ KNAPSACK_PRO_COMMIT_HASH=MY_COMMIT \
 KNAPSACK_PRO_CI_NODE_BUILD_ID=MY_BUILD_ID \
 KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true \
 KNAPSACK_PRO_TEST_FILE_PATTERN="{**/__tests__/**/*.js?(x),**/?(*.)(spec|test).js?(x)}" \
-$(npm bin)/knapsack-pro-jest --runInBand
+npx knapsack-pro-jest --runInBand
 ```
 
 `KNAPSACK_PRO_CI_NODE_BUILD_ID` must be the same as the CI build you are trying to reproduce (if it helps, take a look at what Knapsack Pro uses as `ciNodeBuildId` for your [CI provider](https://github.com/KnapsackPro/knapsack-pro-core-js/tree/master/src/ci-providers)).


### PR DESCRIPTION
npm bin was removed in npm v9 https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/

See also [message](https://knapsackpro.slack.com/archives/C045M8ZGX8A/p1683237818321839) from Artur on Slack.