### PR TITLE
Update queue mode hooks examples to call them once and also call them when using rspec without knapsack pro.

### DIFF
--- a/docusaurus/docs/ruby/hooks.md
+++ b/docusaurus/docs/ruby/hooks.md
@@ -3,6 +3,11 @@ pagination_next: null
 pagination_prev: null
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import BeforeSuiteHookQueueMode from './hooks/_before_suite_hook_queue_mode.md';
+import AfterSuiteHookQueueMode from './hooks/_after_suite_hook_queue_mode.md';
+
 # Hooks: Before and After
 
 :::caution
@@ -39,21 +44,21 @@ end
 
 ## RSpec
 
-If you are using Knapsack Pro in Queue Mode with RSpec, replace:
+If you use Knapsack Pro in Queue Mode with RSpec hooks:
 
 ```ruby
 before(:suite) { ... }
 after(:suite) { ... }
 ```
 
-with:
+Then you need to start using Queue Mode hooks:
 
 ```ruby
 KnapsackPro::Hooks::Queue.before_queue { ... }
 KnapsackPro::Hooks::Queue.after_queue { ... }
 ```
 
-Otherwise, Knapsack Pro would call `before(:suite)` and `after(:suite)` for each subset of tests.
+Otherwise, Knapsack Pro would call `before(:suite)` and `after(:suite)` for each subset of tests fetched from Queue API.
 
 For example, what follows are the hooks run with two subsets of tests:
 
@@ -74,6 +79,17 @@ after :suite
 
 after_queue
 ```
+
+Here are examples of how to define hooks properly so that they are called only once:
+
+<Tabs>
+  <TabItem value="junit-formatter" label="Before suite hook" default>
+    <BeforeSuiteHookQueueMode />
+  </TabItem>
+  <TabItem value="json-formatter" label="After suite hook">
+    <AfterSuiteHookQueueMode />
+  </TabItem>
+</Tabs>
 
 ## `percy-capybara`
 

--- a/docusaurus/docs/ruby/hooks/_after_suite_hook_queue_mode.md
+++ b/docusaurus/docs/ruby/hooks/_after_suite_hook_queue_mode.md
@@ -1,0 +1,22 @@
+```ruby
+# spec_helper.rb
+
+after_suite_block = proc {
+  puts 'after suite hook called only once'
+}
+
+unless KnapsackPro::Config::Env.queue_recording_enabled?
+  RSpec.configure do |config|
+    config.after(:suite) do
+      after_suite_block.call
+      puts 'Run this only when not using Knapsack Pro Queue Mode'
+    end
+  end
+end
+
+KnapsackPro::Hooks::Queue.after_queue do |queue_id|
+  after_suite_block.call
+  puts 'Run this only when using Knapsack Pro Queue Mode'
+  puts "This code is executed outside of the RSpec after(:suite) hook context because it's impossible to determine which after(:suite) is the last one to execute until it's executed."
+end
+```

--- a/docusaurus/docs/ruby/hooks/_after_suite_hook_queue_mode.md
+++ b/docusaurus/docs/ruby/hooks/_after_suite_hook_queue_mode.md
@@ -17,6 +17,7 @@ end
 KnapsackPro::Hooks::Queue.after_queue do |queue_id|
   after_suite_block.call
   puts 'Run this only when using Knapsack Pro Queue Mode'
-  puts "This code is executed outside of the RSpec after(:suite) hook context because it's impossible to determine which after(:suite) is the last one to execute until it's executed."
+  puts "This code is executed outside of the RSpec after(:suite) hook context because it's " +
+    "impossible to determine which after(:suite) is the last one to execute until it's executed."
 end
 ```

--- a/docusaurus/docs/ruby/hooks/_before_suite_hook_queue_mode.md
+++ b/docusaurus/docs/ruby/hooks/_before_suite_hook_queue_mode.md
@@ -1,0 +1,22 @@
+```ruby
+# spec_helper.rb
+
+before_suite_block = proc {
+  puts 'RSpec before suite hook called only once'
+}
+
+unless KnapsackPro::Config::Env.queue_recording_enabled?
+  RSpec.configure do |config|
+    config.before(:suite) do
+      before_suite_block.call
+      puts 'Run this only when not using Knapsack Pro Queue Mode'
+    end
+  end
+end
+
+KnapsackPro::Hooks::Queue.before_queue do |queue_id|
+  before_suite_block.call
+  puts 'Run this only when using Knapsack Pro Queue Mode'
+  puts 'This code is executed within the context of RSpec before(:suite) hook'
+end
+```


### PR DESCRIPTION
Update queue mode hooks examples to call them once and also call them when using rspec without knapsack pro.