### PR TITLE
update(rspec troubleshooting docs): add an example of using the timeout program to debug a freezed CI node

### DIFF
--- a/docusaurus/docs/ruby/troubleshooting.mdx
+++ b/docusaurus/docs/ruby/troubleshooting.mdx
@@ -116,6 +116,14 @@ Some users reported frozen CI nodes with:
   kill -USR1 <process pid>
   ```
 
+  Alternatively, you can use the `timeout` program to send the USR1 signal after Knapsack runs too long.
+
+  ```bash
+  timeout --signal=USR1 600 bundle exec rake "knapsack_pro:queue:rspec[--format d]"
+  ```
+
+  Notice that `600` is in seconds. It sends the signal after 10 minutes of running the command. You may want to adjust that number to ensure the USR1 signal is sent after the process is stuck and not before.
+
 ## Knapsack Pro does not work on a forked repository
 
 :::caution


### PR DESCRIPTION
RSpec: Add an example of using the timeout program to debug a freezed CI node.

It's common that CI provider does not allow to ssh into already running CI node so it's hard to send the USR1 signal your self to the freezed knapsack process. But you can do it with the `timeout` program. This PR documented that.

Inspired by:
https://github.com/KnapsackPro/knapsack_pro-ruby/issues/255#issuecomment-2126626420