### PR TITLE
Add an explanation for multiple API tokens on the Ruby, Jest & Cypress installation guide

### DIFF
--- a/docusaurus/docs/cypress/guide/index.mdx
+++ b/docusaurus/docs/cypress/guide/index.mdx
@@ -70,7 +70,7 @@ Now, fill in the following form to generate the instruction steps for your proje
 
 ### AppVeyor
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_appveyor) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_appveyor) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 For each parallel job, define:
 
@@ -119,7 +119,7 @@ npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false
 
 ### Buildkite
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_buildkite) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_buildkite) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Remember to configure the `parallelism` parameter in your build step.
 
@@ -185,7 +185,7 @@ You can also check out the following example repositories for Ruby on Rails proj
 
 ### CircleCI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_circleci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_circleci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Remember to add additional parallel containers in the CircleCI settings.
 
@@ -215,7 +215,7 @@ Here you can find an example of a [Rails application configured with Knapsack Pr
 
 ### Cirrus CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_cirrusci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_cirrusci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Configure the number of parallel CI nodes with the [matrix modification](https://cirrus-ci.org/guide/writing-tasks/#matrix-modification):
 
@@ -241,7 +241,7 @@ Here is an example of a [`.cirrus.yml` configuration file](https://cirrus-ci.org
 
 ### CloudBees CodeShip
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_codeship) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_codeship) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 For each [parallel pipeline](https://documentation.codeship.com/basic/builds-and-configuration/parallel-tests/#using-parallel-test-pipelines), define:
 
@@ -290,7 +290,7 @@ Consider moving the `KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS` to the _Environment_
 
 ### Codefresh
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_codefresh) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_codefresh) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `.codefresh/codefresh.yml`:
 
@@ -388,7 +388,7 @@ RUN npm install
 
 ### GitHub Actions
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_githubactions) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_githubactions) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `.github/workflows/main.yaml`:
 
@@ -450,7 +450,7 @@ jobs:
 
 ### GitLab CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_gitlabci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_gitlabci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 #### GitLab CI >= 11.5
 
@@ -508,7 +508,7 @@ Remember to set up the `KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS` as [Secret Variab
 
 ### Heroku CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_herokuci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_herokuci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `app.json`:
 
@@ -548,7 +548,7 @@ Remember to set up the `KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS` outside of `app.j
 
 ### Jenkins
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_jenkins) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_jenkins) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 In order to run parallel jobs with Jenkins you should use Jenkins Pipeline as described in [Parallelism and Distributed Builds with Jenkins](https://www.cloudbees.com/blog/parallelism-and-distributed-builds-jenkins).
 
@@ -610,7 +610,7 @@ Consider setting up the `KNAPSACK_PRO_TEST_SUITE_TOKEN_*` as global environment 
 
 ### Semaphore CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_semaphoreci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_semaphoreci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `.semaphore/semaphore.yml`:
 
@@ -660,7 +660,7 @@ Remember to set up `KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS` as a [secret](https:/
 
 ### Travis CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_travisci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_travisci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `.travis.yml`:
 
@@ -692,7 +692,7 @@ You can find more info about the global and matrix env configuration in the [Tra
 
 ### Other CI provider
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_otherci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-cypress&utm_content=installation_guide_otherci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define the following global environment variables on your CI server:
 

--- a/docusaurus/docs/jest/guide/index.mdx
+++ b/docusaurus/docs/jest/guide/index.mdx
@@ -68,7 +68,7 @@ Now, fill in the following form to generate the instruction steps for your proje
 
 ### AppVeyor
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_appveyor) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_appveyor) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 For each parallel job, define:
 
@@ -117,7 +117,7 @@ npx knapsack-pro-jest --runInBand
 
 ### Buildkite
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_buildkite) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_buildkite) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Remember to configure the `parallelism` parameter in your build step.
 
@@ -183,7 +183,7 @@ You can also check out the following example repositories for Ruby on Rails proj
 
 ### CircleCI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_circleci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_circleci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Remember to add additional parallel containers in the CircleCI settings.
 
@@ -213,7 +213,7 @@ Here you can find an example of a [Rails project config on CircleCI 2.0](https:/
 
 ### Cirrus CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_cirrusci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_cirrusci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Configure the number of parallel CI nodes with the [matrix modification](https://cirrus-ci.org/guide/writing-tasks/#matrix-modification):
 
@@ -239,7 +239,7 @@ Here is an example of a [`.cirrus.yml` configuration file](https://cirrus-ci.org
 
 ### CloudBees CodeShip
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_codeship) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_codeship) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 For each [parallel pipeline](https://documentation.codeship.com/basic/builds-and-configuration/parallel-tests/#using-parallel-test-pipelines), define:
 
@@ -288,7 +288,7 @@ Consider moving the `KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST` to the _Environment_ pa
 
 ### Codefresh
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_codefresh) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_codefresh) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `.codefresh/codefresh.yml`:
 
@@ -385,7 +385,7 @@ RUN npm install
 
 ### GitHub Actions
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_githubactions) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_githubactions) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `.github/workflows/main.yaml`:
 
@@ -443,7 +443,7 @@ jobs:
 
 ### GitLab CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_gitlabci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_gitlabci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 #### GitLab CI >= 11.5
 
@@ -501,7 +501,7 @@ Remember to set up the `KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST` as [Secret Variables
 
 ### Heroku CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_herokuci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_herokuci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `app.json`:
 
@@ -541,7 +541,7 @@ Remember to set up the `KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST` outside of `app.json
 
 ### Jenkins
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_jenkins) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_jenkins) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 In order to run parallel jobs with Jenkins you should use Jenkins Pipeline as described in [Parallelism and Distributed Builds with Jenkins](https://www.cloudbees.com/blog/parallelism-and-distributed-builds-jenkins).
 
@@ -603,7 +603,7 @@ Consider setting up the `KNAPSACK_PRO_TEST_SUITE_TOKEN_*` as global environment 
 
 ### Semaphore CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_semaphoreci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_semaphoreci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `.semaphore/semaphore.yml`:
 
@@ -653,7 +653,7 @@ Remember to set up `KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST` as a [secret](https://do
 
 ### Travis CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_travisci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_travisci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `.travis.yml`:
 
@@ -685,7 +685,7 @@ You can find more info about the global and matrix env configuration in the [Tra
 
 ### Other CI provider
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_otherci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack-pro-jest&utm_content=installation_guide_otherci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define the following global environment variables on your CI server:
 

--- a/docusaurus/docs/knapsack_pro-ruby/guide/index.mdx
+++ b/docusaurus/docs/knapsack_pro-ruby/guide/index.mdx
@@ -167,7 +167,7 @@ KnapsackPro::Adapters::SpinachAdapter.bind
 
 ### AppVeyor
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_appveyor) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_appveyor) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 For each parallel job, define:
 
@@ -243,7 +243,7 @@ bundle exec rake knapsack_pro:queue:cucumber
 
 ### Buildkite
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_buildkite) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_buildkite) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Remember to configure the `parallelism` parameter in your build step.
 
@@ -334,7 +334,7 @@ You can also check out the following example repositories for Ruby on Rails proj
 
 ### CircleCI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_circleci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_circleci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Remember to add additional parallel containers in the CircleCI settings.
 
@@ -379,7 +379,7 @@ See how to configure [advanced CircleCI features](../../ruby/circleci.mdx) with 
 
 ### Cirrus CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_cirrusci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_cirrusci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Configure the number of parallel CI nodes with the [matrix modification](https://cirrus-ci.org/guide/writing-tasks/#matrix-modification):
 
@@ -411,7 +411,7 @@ Here is an example of a [`.cirrus.yml` configuration file](https://cirrus-ci.org
 
 ### CloudBees CodeShip
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_codeship) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_codeship) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 For each [parallel pipeline](https://documentation.codeship.com/basic/builds-and-configuration/parallel-tests/#using-parallel-test-pipelines), define:
 
@@ -487,7 +487,7 @@ Consider moving the `KNAPSACK_PRO_TEST_SUITE_TOKEN_*` to the _Environment_ page 
 
 ### Codefresh
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_codefresh) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_codefresh) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `.codefresh/codefresh.yml`:
 
@@ -615,7 +615,7 @@ RUN bundle install
 
 ### GitHub Actions
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_githubactions) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_githubactions) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `.github/workflows/main.yaml`:
 
@@ -716,7 +716,7 @@ jobs:
 
 ### GitLab CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_gitlabci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_gitlabci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 #### GitLab CI >= 11.5
 
@@ -786,7 +786,7 @@ Remember to set up the `KNAPSACK_PRO_TEST_SUITE_TOKEN_*` as [Secret Variables](h
 
 ### Heroku CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_herokuci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_herokuci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `app.json`:
 
@@ -826,7 +826,7 @@ Remember to set up the `KNAPSACK_PRO_TEST_SUITE_TOKEN_*` outside of `app.json` i
 
 ### Jenkins
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_jenkins) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_jenkins) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 In order to run parallel jobs with Jenkins you should use Jenkins Pipeline as described in [Parallelism and Distributed Builds with Jenkins](https://www.cloudbees.com/blog/parallelism-and-distributed-builds-jenkins).
 
@@ -897,7 +897,7 @@ Consider setting up the `KNAPSACK_PRO_TEST_SUITE_TOKEN_*` as global environment 
 
 ### Semaphore CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_semaphoreci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_semaphoreci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `.semaphore/semaphore.yml`:
 
@@ -975,7 +975,7 @@ Remember to set up `KNAPSACK_PRO_TEST_SUITE_TOKEN_*` as a [secret](https://docs.
 
 ### Travis CI
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_travisci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_travisci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define in `.travis.yml`:
 
@@ -1015,7 +1015,7 @@ You can find more info about the global and matrix env configuration in the [Tra
 
 ### Other CI provider
 
-Generate [API tokens](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_otherci) for each Knapsack Pro command.
+[Generate an API token](https://knapsackpro.com/dashboard?utm_source=docs_knapsackpro&utm_medium=page&utm_campaign=knapsack_pro-ruby_gem&utm_content=installation_guide_otherci) for each Knapsack Pro command on the CI. Each command needs its own API token to treat every test suite as a separate entity.
 
 Define the following global environment variables on your CI server:
 


### PR DESCRIPTION
update(docs): add an explanation for multiple API tokens on the Ruby, Jest & Cypress installation guide.