### PR TITLE
Update docs: Add KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD to improve the RSpec split by examples feature with many skipped tests

### DIFF
--- a/docusaurus/docs/ruby/reference.md
+++ b/docusaurus/docs/ruby/reference.md
@@ -273,6 +273,30 @@ KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN="{spec/models/user_spec.rb,spec/controllers/
 
 Make sure to read the details in [Split by test examples](split-by-test-examples.mdx).
 
+## `KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD`
+
+:::caution
+
+This option takes effect if you split test files by test cases among parallel CI nodes using:
+
+* [`KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true`](split-by-test-examples.mdx)
+
+:::
+
+Default: not set
+
+Available:
+
+- not set: automatically determines the slow test files threshold
+- Set a number of seconds. Test files above the threshold are split by test cases among parallel CI nodes.
+
+Example:
+
+```bash
+# 180 seconds (3 minutes)
+KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD=180
+```
+
 ## `KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES` (RSpec)
 
 Parallelize test examples (instead of files) across CI nodes.

--- a/docusaurus/docs/ruby/split-by-test-examples.mdx
+++ b/docusaurus/docs/ruby/split-by-test-examples.mdx
@@ -128,9 +128,9 @@ Does not support [`run_all_when_everything_filtered`](rspec.mdx#some-of-my-test-
 
 ### Why aren’t some test files split by examples?
 
-When many test files are skipped (e.g., with `--tag ~skip`), the actual CI node time may fall short of estimates since Knapsack Pro can’t detect filtered files, marking fewer test files as slow and unbalancing the CI build.
+When many test files are skipped (e.g., with `--tag ~skip`), the actual CI node time may fall short of estimates, marking fewer test files as slow and unbalancing the CI build.
 
-You can manually set a threshold for splitting test files by examples with [`KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD`](reference.md#knapsack_pro_slow_test_file_threshold).
+You can manually set a threshold for splitting test files by examples with [`KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD`](reference.md#knapsack_pro_slow_test_file_threshold). This should help with unbalanced CI builds.
 
 ### Why are some of my test files not executed?
 

--- a/docusaurus/docs/ruby/split-by-test-examples.mdx
+++ b/docusaurus/docs/ruby/split-by-test-examples.mdx
@@ -12,6 +12,7 @@ import { IconExternalLink } from '@site/src/components/IconExternalLink'
 
 - [`KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES`](reference.md#knapsack_pro_rspec_split_by_test_examples-rspec)
 - [`KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX`](reference.md#knapsack_pro_rspec_test_example_detector_prefix-rspec)
+- [`KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD`](reference.md#knapsack_pro_slow_test_file_threshold)
 
 </TOCBottom>
 

--- a/docusaurus/docs/ruby/split-by-test-examples.mdx
+++ b/docusaurus/docs/ruby/split-by-test-examples.mdx
@@ -126,6 +126,12 @@ Does not support [`run_all_when_everything_filtered`](rspec.mdx#some-of-my-test-
 
 ## Troubleshooting
 
+### Why aren’t some test files split by examples?
+
+When many test files are skipped (e.g., with `--tag ~skip`), the actual CI node time may fall short of estimates since Knapsack Pro can’t detect filtered files, marking fewer test files as slow and unbalancing the CI build.
+
+You can manually set a threshold for splitting test files by examples with [`KNAPSACK_PRO_SLOW_TEST_FILE_THRESHOLD`](reference.md#knapsack_pro_slow_test_file_threshold).
+
 ### Why are some of my test files not executed?
 
 Read the answer on the [RSpec page](rspec.mdx#some-of-my-test-files-are-not-executed).


### PR DESCRIPTION
# related

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/282