### PR TITLE
update(docs): a default DB configuration for Heroku CI that has an isolated DB per node

### DIFF
--- a/_posts/2018-12-01-how-to-run-parallel-dynos-on-heroku-ci-to-complete-tests-faster.md
+++ b/_posts/2018-12-01-how-to-run-parallel-dynos-on-heroku-ci-to-complete-tests-faster.md
@@ -43,7 +43,8 @@ We can split Ruby tests written in RSpec, Minitest or other tests runners across
         }
       },
       "addons": [
-        "heroku-postgresql"
+        "heroku-postgresql:in-dyno",
+        "heroku-redis:in-dyno"
       ],
       "scripts": {
         "test": "bundle exec rake knapsack_pro:rspec"
@@ -90,7 +91,8 @@ Here is a config for your <i>app.json</i>
         }
       },
       "addons": [
-        "heroku-postgresql"
+        "heroku-postgresql:in-dyno",
+        "heroku-redis:in-dyno"
       ],
       "scripts": {
         "test": "$(npm bin)/knapsack-pro-cypress"

--- a/_posts/2019-05-25-how-to-run-tests-faster-on-heroku-ci-with-parallel-dynos.md
+++ b/_posts/2019-05-25-how-to-run-tests-faster-on-heroku-ci-with-parallel-dynos.md
@@ -43,7 +43,8 @@ You can split Ruby tests written in RSpec, Minitest, Cucumber or other tests run
         }
       },
       "addons": [
-        "heroku-postgresql"
+        "heroku-postgresql:in-dyno",
+        "heroku-redis:in-dyno"
       ],
       "scripts": {
         "test": "bundle exec rake knapsack_pro:queue:rspec"
@@ -90,7 +91,8 @@ Here is a config for your <i>app.json</i>
         }
       },
       "addons": [
-        "heroku-postgresql"
+        "heroku-postgresql:in-dyno",
+        "heroku-redis:in-dyno"
       ],
       "scripts": {
         "test": "$(npm bin)/knapsack-pro-cypress"
@@ -121,7 +123,8 @@ Here is a config for your <i>app.json</i>
         }
       },
       "addons": [
-        "heroku-postgresql"
+        "heroku-postgresql:in-dyno",
+        "heroku-redis:in-dyno"
       ],
       "scripts": {
         "test": "$(npm bin)/knapsack-pro-jest"

--- a/docusaurus/docs/cypress/guide/index.mdx
+++ b/docusaurus/docs/cypress/guide/index.mdx
@@ -526,7 +526,10 @@ Define in `app.json`:
           "quantity": 2
         }
       },
-      "addons": ["heroku-postgresql"],
+      "addons": [
+        "heroku-postgresql:in-dyno",
+        "heroku-redis:in-dyno"
+      ],
       // highlight-start
       "scripts": {
         "test": "npx knapsack-pro-cypress --config trashAssetsBeforeRuns=false"

--- a/docusaurus/docs/jest/guide/index.mdx
+++ b/docusaurus/docs/jest/guide/index.mdx
@@ -519,7 +519,10 @@ Define in `app.json`:
           "quantity": 2
         }
       },
-      "addons": ["heroku-postgresql"],
+      "addons": [
+        "heroku-postgresql:in-dyno",
+        "heroku-redis:in-dyno"
+      ],
       // highlight-start
       "scripts": {
         "test": "npx knapsack-pro-jest --runInBand"

--- a/docusaurus/docs/knapsack_pro-ruby/guide/index.mdx
+++ b/docusaurus/docs/knapsack_pro-ruby/guide/index.mdx
@@ -804,7 +804,10 @@ Define in `app.json`:
           "quantity": 2
         }
       },
-      "addons": ["heroku-postgresql"],
+      "addons": [
+        "heroku-postgresql:in-dyno",
+        "heroku-redis:in-dyno"
+      ],
       // highlight-start
       "scripts": {
         "test": "bundle exec rake knapsack_pro:queue:rspec"

--- a/docusaurus/docs/ruby/heroku.md
+++ b/docusaurus/docs/ruby/heroku.md
@@ -20,7 +20,10 @@ You can create a script as described in [Run multiple test suites with one scrip
           "quantity": 2
         }
       },
-      "addons": ["heroku-postgresql"],
+      "addons": [
+        "heroku-postgresql:in-dyno",
+        "heroku-redis:in-dyno"
+      ],
       "scripts": {
         "test": "bin/knapsack_pro_run_tests"
       },


### PR DESCRIPTION
We suggest a default DB configuration for Heroku CI that has an isolated DB per node.

https://devcenter.heroku.com/articles/heroku-ci-parallel-test-runs#databases-in-parallel-test-runs

> Dynos in a parallel test run share the same instance of any databases (and other add-ons) provisioned for the test run. This means that a Heroku Postgres instance might be shared between up to 32 dynos.
> 
> Many testing frameworks expect to have exclusive access to databases. If this is the case for your testing framework, your test runs can provision special in-dyno plans for Heroku Postgres and Heroku Key-Value Store. Modify the plans for these add-ons in your app.json file like so:

```
{
  "addons": [
    "heroku-postgresql:in-dyno",
    "heroku-redis:in-dyno"
  ]
}
```