### PR TITLE
Fix broken 404 outgoing links

### DIFF
--- a/_posts/2019-03-16-run-parallel-jobs-on-semaphore-ci-2-0-to-get-faster-ci-build-time.md
+++ b/_posts/2019-03-16-run-parallel-jobs-on-semaphore-ci-2-0-to-get-faster-ci-build-time.md
@@ -31,7 +31,7 @@ Here you can find Semaphore CI 2.0 config for projects using:
 
 `knapsack_pro` gem supports environment variables provided by Semaphore CI 2.0 to run your tests. You will have to define a few things in `.semaphore/semaphore.yml` config file.
 
-- You need to set `KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC`. If you don't want to commit secrets in yml file then you can <a href="https://docs.semaphoreci.com/article/66-environment-variables-and-secrets" target="_blank" rel="nofollow">follow this guide</a>.
+- You need to set `KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC`. If you don't want to commit secrets in yml file then you can <a href="https://docs.semaphoreci.com/using-semaphore/secrets" target="_blank" rel="nofollow">follow this guide</a>.
 - You should create as many parallel jobs as you need with `parallelism` property. If your test suite is long you should use more parallel jobs.
 
 Below you can find full Semaphore CI 2.0 config for Rails project.
@@ -135,7 +135,7 @@ blocks:
 
 `@knapsack-pro/cypress` supports environment variables provided by Semaphore CI 2.0 to run your tests. You will have to define a few things in `.semaphore/semaphore.yml` config file.
 
-- You need to set `KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS`. If you don't want to commit secrets in yml file then you can <a href="https://docs.semaphoreci.com/article/66-environment-variables-and-secrets" target="_blank" rel="nofollow">follow this guide</a>.
+- You need to set `KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS`. If you don't want to commit secrets in yml file then you can <a href="https://docs.semaphoreci.com/using-semaphore/secrets" target="_blank" rel="nofollow">follow this guide</a>.
 - You should create as many parallel jobs as you need with `parallelism` property. If your test suite is long you should use more parallel jobs.
 
 Below you can find example part of Semaphore CI 2.0 config.
@@ -164,7 +164,7 @@ blocks:
 
 `@knapsack-pro/jest` supports environment variables provided by Semaphore CI 2.0 to run your tests. You will have to define a few things in `.semaphore/semaphore.yml` config file.
 
-- You need to set `KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST`. If you don't want to commit secrets in yml file then you can <a href="https://docs.semaphoreci.com/article/66-environment-variables-and-secrets" target="_blank" rel="nofollow">follow this guide</a>.
+- You need to set `KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST`. If you don't want to commit secrets in yml file then you can <a href="https://docs.semaphoreci.com/using-semaphore/secrets" target="_blank" rel="nofollow">follow this guide</a>.
 - You should create as many parallel jobs as you need with `parallelism` property. If your test suite is long you should use more parallel jobs.
 
 Below you can find example part of Semaphore CI 2.0 config.

--- a/_posts/2021-02-25-best-heroku-add-ons-for-ruby-on-rails-project.md
+++ b/_posts/2021-02-25-best-heroku-add-ons-for-ruby-on-rails-project.md
@@ -74,16 +74,6 @@ Rollbar.configure do |config|
 end
 {% endhighlight %}
 
-### Logentries
-
-[Logentries](https://elements.heroku.com/addons/logentries) - collects your logs from Heroku standard output so that you can browse them later on. If you need to find info about an issue that happened a few days ago in your logs then Logentries might be helpful.
-
-Of course, you could use [Heroku Command Line Interface](https://devcenter.heroku.com/articles/heroku-cli) and run `heroku logs -n 10000 --app my-heroku-app` command in terminal to browse logs for the last 10,000 lines but this method has limitations. You can't go that much in past logs or easily filter logs as in Logentries.
-
-Logentries has a 5 GB and 7 days retention period in a free plan. This is enough for small Rails apps.
-
-A nice feature I like in Logentries is an option to save the query and later on quickly browse logs by it. You can also display charts based on logs. Maybe you want to see how often a particular worker in Sidekiq has been called? You could visualize it.
-
 ### Redis Cloud
 
 If you use Redis in your Ruby on Rails app then [Redis Cloud](https://elements.heroku.com/addons/rediscloud) is your add-on. It has a free plan and paid plans are more affordable than other add-ons have.

--- a/docusaurus/docs/cypress/guide/index.mdx
+++ b/docusaurus/docs/cypress/guide/index.mdx
@@ -655,7 +655,7 @@ blocks:
       # highlight-end
 ```
 
-Remember to set up `KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS` as a [secret](https://docs.semaphoreci.com/article/66-environment-variables-and-secrets).
+Remember to set up `KNAPSACK_PRO_TEST_SUITE_TOKEN_CYPRESS` as a [secret](https://docs.semaphoreci.com/using-semaphore/secrets).
 
 </ShowIfSearchParamAndValue>
 

--- a/docusaurus/docs/jest/guide/index.mdx
+++ b/docusaurus/docs/jest/guide/index.mdx
@@ -648,7 +648,7 @@ blocks:
       # highlight-end
 ```
 
-Remember to set up `KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST` as a [secret](https://docs.semaphoreci.com/article/66-environment-variables-and-secrets).
+Remember to set up `KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST` as a [secret](https://docs.semaphoreci.com/using-semaphore/secrets).
 
 </ShowIfSearchParamAndValue>
 

--- a/docusaurus/docs/knapsack_pro-ruby/guide/index.mdx
+++ b/docusaurus/docs/knapsack_pro-ruby/guide/index.mdx
@@ -970,7 +970,7 @@ blocks:
       # highlight-end
 ```
 
-Remember to set up `KNAPSACK_PRO_TEST_SUITE_TOKEN_*` as a [secret](https://docs.semaphoreci.com/article/66-environment-variables-and-secrets).
+Remember to set up `KNAPSACK_PRO_TEST_SUITE_TOKEN_*` as a [secret](https://docs.semaphoreci.com/using-semaphore/secrets).
 
 </ShowIfSearchParamAndValue>
 


### PR DESCRIPTION
* update(blog post): remove Logentries from the blog post. Logentries is removed from Heroku marketplace
* fix Semaphore secret links